### PR TITLE
Connect via Public IP address

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Instance struct {
-	InstanceID, PrivateIP, State           string
+	InstanceID, PrivateIP, PublicIP, State string
 	Up                                     time.Duration
 	Tags                                   map[string]string
 	ICMPPing, SSHPing, HTTPPing, HTTPSPing <-chan PingResponse
@@ -17,7 +17,7 @@ type Instance struct {
 
 func NewInstance(i *ec2.Instance) *Instance {
 	return &Instance{
-		*i.InstanceId, *i.PrivateIpAddress, *i.State.Name,
+		*i.InstanceId, *i.PrivateIpAddress, *i.PublicIpAddress, *i.State.Name,
 		time.Since(*i.LaunchTime),
 		TagMap(i.Tags),
 		ICMPPing(*i.PrivateIpAddress),

--- a/main.go
+++ b/main.go
@@ -159,7 +159,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "[41;1mWarning: agent forwarding not enabled[K[m")
 	}
 
-	if os.Getenv("JUMP_IP") == "public" {
+	if os.Getenv("JUMP_PUBLIC") != "" {
 		publicIP = true
 	}
 


### PR DESCRIPTION
Now you can connect without being inside the VPC or having a bastion!

Simply set the environment variable `JUMP_PUBLIC` to any non-empty string. For example, `JUMP_PUBLIC=yes ./jump blah blah blah`
