### PR TITLE
Add support for bastion host

### DIFF
--- a/bastion.go
+++ b/bastion.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/url"
+	"os"
+	"os/user"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+// BastionDialer returns a bastion
+func BastionDialer(
+	bastionHost string,
+) (func(network, addr string) (net.Conn, error), error) {
+	auths := []ssh.AuthMethod{}
+	auths = append(auths, agentAuth()...)
+
+	config := &ssh.ClientConfig{}
+	config.SetDefaults()
+
+	u, err := url.Parse("//" + bastionHost)
+	if err != nil {
+		return nil, err
+	}
+
+	if u.User == nil || u.User.Username() == "" {
+		whoami, err := user.Current()
+		if err != nil {
+			return nil, err
+		}
+		u.User = url.User(whoami.Username)
+	}
+
+	_, _, err = net.SplitHostPort(u.Host)
+	if err != nil {
+		u.Host += ":ssh"
+	}
+
+	config.User = u.User.Username()
+	config.Auth = auths
+
+	log.Printf("Using bastion host: %v", u.Host)
+	conn, err := ssh.Dial("tcp", u.Host, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to %q: %v", bastionHost, err)
+	}
+	return conn.Dial, nil
+}
+
+func agentAuth() (auths []ssh.AuthMethod) {
+	if sock := os.Getenv("SSH_AUTH_SOCK"); len(sock) > 0 {
+		if agconn, err := net.Dial("unix", sock); err == nil {
+			ag := agent.NewClient(agconn)
+			auths = append(auths, ssh.PublicKeysCallback(ag.Signers))
+		}
+	}
+	return auths
+}


### PR DESCRIPTION
With this change we can jump via a bastion host. Be aware that the bastion's host key is not currently checked.

The AWS calls are run as if they were run on the bastion host via TCP tunnelling. This enables using the remote's EC2 Role to list machines.

It works by setting `JUMP_BASTION` to a hostname. The supported format is
`[user@]host[:port]`. If `user` is missing, the current username is used, and if `:port` is missing it defaults to 22.

The remote machine must have credentials enabling it to run `ec2.DescribeInstances` for this to be useful.
