### PR TITLE
Filter instances by bastion VPC

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -9,15 +9,16 @@ import (
 )
 
 type Instance struct {
-	InstanceID, PrivateIP, PublicIP, State string
-	Up                                     time.Duration
-	Tags                                   map[string]string
-	ICMPPing, SSHPing, HTTPPing, HTTPSPing <-chan PingResponse
+	InstanceID, PrivateIP, PublicIP, State, VPCID string
+	Up                                            time.Duration
+	Tags                                          map[string]string
+	ICMPPing, SSHPing, HTTPPing, HTTPSPing        <-chan PingResponse
 }
 
 func NewInstance(i *ec2.Instance) *Instance {
 	return &Instance{
 		*i.InstanceId, *i.PrivateIpAddress, *i.PublicIpAddress, *i.State.Name,
+		*i.VpcId,
 		time.Since(*i.LaunchTime),
 		TagMap(i.Tags),
 		ICMPPing(*i.PrivateIpAddress),


### PR DESCRIPTION
If you're SSH'ing to a bastion, probably you only want to see machines
which are in the same VPC. This means you don't get machines listed
which aren't reachable.

In the future we might want to make this somehow configurable, but I
don't have a use case for that yet.
