### PR TITLE
Number instances from 1 rather than from 0

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func ShowInstances(instances []*Instance) {
 
 	for n, i := range instances {
 		row := []string{
-			fmt.Sprint(n), i.InstanceID[2:], i.Name(), i.PrettyState(),
+			fmt.Sprint(n + 1), i.InstanceID[2:], i.Name(), i.PrettyState(),
 			i.preferredIP(), fmtDuration(i.Up),
 			(<-i.ICMPPing).String(),
 			(<-i.SSHPing).String(),
@@ -69,7 +69,7 @@ func GetInstanceFromUser(max int) int {
 	if n >= max {
 		log.Fatalln("%d is not a valid instance", n)
 	}
-	return n
+	return n - 1
 }
 
 func InvokeSSH(bastion string, instance *Instance) {


### PR DESCRIPTION
As a programmer, I like to count from 0. But 0 is on the wrong side of
the keyboard, so the order of instances doesn't match the order of the
keys.

This rectifies that, so that now there is a spatial mapping between the
instances shown and the keys you press.
